### PR TITLE
Check jsPDF availability in admin page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -64,7 +64,21 @@
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 <script>
+  window.jsPDF = window.jspdf?.jsPDF;
+</script>
+<script>
+  const jsPDF = window.jspdf?.jsPDF;
+  if (!jsPDF || !window.jspdf.jsPDF.API.autoTable) {
+    console.error("jsPDF o autoTable no están disponibles");
+  }
+</script>
+<script>
   document.getElementById('descargarPDF').addEventListener('click', () => {
+    const jsPDF = window.jspdf?.jsPDF;
+    if (!jsPDF || !window.jspdf.jsPDF.API.autoTable) {
+      console.error("jsPDF o autoTable no están disponibles");
+      return;
+    }
     const tabla = document.getElementById('tabla');
     const opt = {
       margin:       0.5,


### PR DESCRIPTION
## Summary
- Alias `window.jsPDF` to `window.jspdf.jsPDF`
- Log an error when `jsPDF` or `autoTable` are missing before generating PDFs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac90e08b9c8321bb3bc3f92e38644e